### PR TITLE
Ilyaevseev openntpd sysconfig

### DIFF
--- a/openntpd/openntpd.service
+++ b/openntpd/openntpd.service
@@ -5,7 +5,7 @@ After=network.target
  
 [Service]
 Type=forking
-ExecStart=/usr/sbin/openntpd
+ExecStart=/bin/sh -c "test -f /etc/sysconfig/openntpd && . /etc/sysconfig/openntpd ; exec /usr/sbin/openntpd $OPTIONS"
 
 [Install]
 WantedBy=multi-user.target

--- a/openntpd/openntpd.spec
+++ b/openntpd/openntpd.spec
@@ -5,7 +5,7 @@
 
 Name:           openntpd
 Version:        5.9p1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        free and easy to use implementation of the network time protocol
 
 Group:          -
@@ -13,6 +13,7 @@ License:        BSD
 URL:            http://www.openntpd.org/
 Source0:        http://ftp2.eu.openbsd.org/pub/OpenBSD/OpenNTPD/%{name}-%{version}.tar.gz
 Source1:        openntpd.service
+Source2:        openntpd.sysconfig
 
 BuildRequires:          systemd
 Requires(pre):          shadow-utils
@@ -45,6 +46,7 @@ make %{?_smp_mflags}
 
 # install service file
 install -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT/%{_unitdir}/openntpd.service
+install -D -m 644 %{SOURCE2} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/openntpd
 
 # move the binary and man page for the ntpd -> openntpd change
 pushd $RPM_BUILD_ROOT
@@ -76,6 +78,7 @@ exit 0
 %files
 %defattr(-,root,root)
 %config(noreplace) %{_sysconfdir}/ntpd.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/openntpd
 %{_sbindir}/*
 %{_unitdir}/openntpd.service
 %doc %{_mandir}

--- a/openntpd/openntpd.sysconfig
+++ b/openntpd/openntpd.sysconfig
@@ -1,0 +1,2 @@
+# Use "-s" for setting the time immediately at startup, as opposed to slowly adjusting the clock.
+#OPTIONS="-s"


### PR DESCRIPTION
Allow to declare daemon startup options in /etc/sysconfig/openntpd file (OPTIONS="...").
The same feature was provided in LinuxTech build for CentOS 6.