### PR TITLE
Openntpd updated from 5.9 to 6.x, with CentOS 6 support added.

### DIFF
--- a/openntpd/openntpd.init
+++ b/openntpd/openntpd.init
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# openntpd	This shell script takes care of starting and stopping
+#		openntpd (NTPv4 daemon).
+#
+# chkconfig: - 58 74
+# description: openntpd is the NTPv4 daemon. \
+# The Network Time Protocol (NTP) is used to synchronize the time of \
+# a computer client or server to another server or reference time source, \
+# such as a radio or satellite receiver or modem.
+
+### BEGIN INIT INFO
+# Provides: ntpd
+# Required-Start: $network $local_fs $remote_fs
+# Required-Stop: $network $local_fs $remote_fs
+# Should-Start: $syslog $named
+# Should-Stop: $syslog $named
+# Short-Description: start and stop openntpd
+# Description: openntpd is the NTPv4 daemon. The Network Time Protocol (NTP)
+#              is used to synchronize the time of a computer client or
+#              server to another server or reference time source, such
+#              as a radio or satellite receiver or modem.
+### END INIT INFO
+
+# Source function library.
+. /etc/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+if [ -f /etc/sysconfig/openntpd ];then
+        . /etc/sysconfig/openntpd
+fi
+
+RETVAL=0
+prog="openntpd"
+lockfile=/var/lock/subsys/$prog
+
+start() {
+	[ "$EUID" != "0" ] && exit 4
+	[ "$NETWORKING" = "no" ] && exit 1
+	[ -x /usr/sbin/openntpd ] || exit 5
+	
+        # Start daemons.
+        echo -n $"Starting $prog: "
+        daemon $prog $OPTIONS
+	RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && touch $lockfile
+	return $RETVAL
+}
+
+stop() {
+	[ "$EUID" != "0" ] && exit 4
+        echo -n $"Shutting down $prog: "
+	killproc $prog
+	RETVAL=$?
+        echo
+        [ $RETVAL -eq 0 ] && rm -f $lockfile
+	return $RETVAL
+}
+
+# See how we were called.
+case "$1" in
+  start)
+	start
+        ;;
+  stop)
+	stop
+        ;;
+  status)
+	status $prog
+	RETVAL=$?
+	;;
+  restart|reload)
+	stop
+	start
+	RETVAL=$?
+	;;
+  condrestart)
+	if [ -f $lockfile ]; then
+	    stop
+	    start
+	    RETVAL=$?
+	fi
+	;;
+  *)
+        echo $"Usage: $0 {start|stop|restart|condrestart|status}"
+        RETVAL=3
+esac
+
+exit $RETVAL

--- a/openntpd/openntpd.spec
+++ b/openntpd/openntpd.spec
@@ -3,22 +3,35 @@
 %define ntpd_user openntpd
 %define ntpd_group openntpd
 
+%define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7) || (0%{?suse_version} && 0%{?suse_version} >=1210)
+
 Name:           openntpd
-Version:        5.9p1
+Version:        6.0p1
 Release:        1%{?dist}
 Summary:        free and easy to use implementation of the network time protocol
 
 Group:          -
 License:        BSD
 URL:            http://www.openntpd.org/
-Source0:        http://ftp2.eu.openbsd.org/pub/OpenBSD/OpenNTPD/%{name}-%{version}.tar.gz
+Source0:        https://github.com/openntpd-portable/openntpd-portable/archive/%{version}.tar.gz
 Source1:        openntpd.service
+Source2:        openntpd.sysconfig
+Source3:        openntpd.init
+Source4:        https://github.com/openntpd-portable/openntpd-openbsd/archive/%{name}-%{version}.tar.gz
 
+BuildRequires:          autoconf, automake, libtool, byacc
+%if %{use_systemd}
 BuildRequires:          systemd
-Requires(pre):          shadow-utils
 Requires(post):         systemd
 Requires(preun):        systemd
 Requires(postun):       systemd
+%else
+Requires:               initscripts
+Requires(postun):       initscripts
+Requires(post):         chkconfig
+Requires(preun):        chkconfig
+%endif
+Requires(pre):          shadow-utils
 
 %description
 OpenNTPD is a FREE, easy to use implementation of the Network Time Protocol. It
@@ -27,7 +40,11 @@ as NTP server itself, redistributing the local clock.
 
 
 %prep
-%setup -q
+%setup -q -n openntpd-portable-%{version} -b 4
+mv ../openntpd-openbsd-openntpd-%{version} ./openbsd
+sed -i.orig 's,git ,/bin/true ,' ./update.sh
+pushd ./openbsd/src/lib/libcrypto/ && ln -s arc4random crypto && popd
+./autogen.sh
 
 # patch the man pages for the ntpd -> openntpd change
 sed -i "s@\.Xr ntpd 8@.Xr openntpd 8@g" src/*.5 src/*.8
@@ -44,7 +61,12 @@ make %{?_smp_mflags}
 %make_install
 
 # install service file
+%if %{use_systemd}
 install -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT/%{_unitdir}/openntpd.service
+%else
+install -D -m 755 %{SOURCE3} $RPM_BUILD_ROOT/%{_initrddir}/openntpd
+%endif
+install -D -m 644 %{SOURCE2} $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/openntpd
 
 # move the binary and man page for the ntpd -> openntpd change
 pushd $RPM_BUILD_ROOT
@@ -62,22 +84,44 @@ exit 0
 
 
 %post
+%if %{use_systemd}
 %systemd_post openntpd.service
+%else
+/sbin/chkconfig --add openntpd
+%endif
 
 
 %preun
+%if %{use_systemd}
 %systemd_preun openntpd.service
+%else
+if [ "$1" = 0 ]; then
+  /sbin/service openntpd stop > /dev/null 2>&1 || :
+  /sbin/chkconfig --del openntpd
+fi
+%endif
 
 
 %postun
+%if %{use_systemd}
 %systemd_postun_with_restart openntpd.service
+%else
+if [ "$1" != 0 ]; then
+  /sbin/service openntpd condrestart > /dev/null 2>&1 || :
+fi
+%endif
 
 
 %files
 %defattr(-,root,root)
 %config(noreplace) %{_sysconfdir}/ntpd.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/openntpd
 %{_sbindir}/*
+%if %{use_systemd}
 %{_unitdir}/openntpd.service
+%else
+%{_initrddir}/openntpd
+%endif
 %doc %{_mandir}
 
 

--- a/openntpd/openntpd.sysconfig
+++ b/openntpd/openntpd.sysconfig
@@ -1,0 +1,2 @@
+# Use "-s" for setting the time immediately at startup, as opposed to slowly adjusting the clock.
+#OPTIONS="-s"


### PR DESCRIPTION
1) Openntpd updated from 5.9 to 6.x

2) CentOS 6 support added (init script taken from http://pkgrepo.linuxtech.net/el6/release/source/openntpd-3.9p1-1.el6.src.rpm with replacing "ntpd" to "openntpd")

3) Sysconfig file added
