### PR TITLE
Disabled patches entirely

### DIFF
--- a/zfs-auto-snapshot/zfs-auto-snapshot.spec
+++ b/zfs-auto-snapshot/zfs-auto-snapshot.spec
@@ -9,8 +9,8 @@ Group:		Applications/System
 License:	GPL2
 URL:		https://github.com/zfsonlinux/%{name}
 Source0:	%{url}/archive/upstream/%{version}/%{name}-upstream-%{version}.tar.gz
-Patch0:     0001-Fix-broken-cron-scripts.patch
-Patch1:     0002-Found-a-way-to-exec-the-process-and-yet-have-it-work.patch
+#Patch0:     0001-Fix-broken-cron-scripts.patch
+#Patch1:     0002-Found-a-way-to-exec-the-process-and-yet-have-it-work.patch
 
 #BuildRequires:
 #Requires:


### PR DESCRIPTION
Entirely disabled patches in SPEC file so anyone can rebuild package easily in Fedora COPR repository by using GIT repo.
Tested it on [freshly created package](https://copr.fedorainfracloud.org/coprs/castor/zfs-auto-snapshot/) and selected SCM source (my git fork and subdirectory `zfs-auto-snapshot`).

Please merge this and rebuild packages in your COPR with SCM-source type (not src.rpm file upload). I want other users of your repository to fetch updates for Fedora 32 and 33 automatically.